### PR TITLE
use release build of DDlog in `ddlog.at`

### DIFF
--- a/tests/ddlog.at
+++ b/tests/ddlog.at
@@ -4,7 +4,7 @@ AT_SETUP([ddlog -- northd])
 AT_SKIP_IF([test "$TEST_DDLOG" != "true"])
 
 DDLOG_TEST_DIR="$(cd $abs_top_builddir/tests/ddlog && pwd)"
-DDLOG_CLI_DIR="$(cd $abs_top_builddir/ovn/northd/ovn_northd_ddlog/target/debug/ && pwd)"
+DDLOG_CLI_DIR="$(cd $abs_top_builddir/ovn/northd/ovn_northd_ddlog/target/release/ && pwd)"
 
 cp $DDLOG_TEST_DIR/ovn_northd.dump.expected expout
 AT_CHECK([$DDLOG_CLI_DIR/ovn_northd_cli < $DDLOG_TEST_DIR/ovn_northd.dat],


### PR DESCRIPTION
`DDLOG_CLI_DIR` in `ddlog.at` used to still point to the debug build of DDlog