### PR TITLE
More DDlog fixes

### DIFF
--- a/lib/packets.c
+++ b/lib/packets.c
@@ -541,6 +541,18 @@ eth_format_masked(const struct eth_addr eth,
     }
 }
 
+void
+in6_addr_solicited_node(struct in6_addr *addr, const struct in6_addr *ip6)
+{
+    union ovs_16aligned_in6_addr *taddr =
+        (union ovs_16aligned_in6_addr *) addr;
+    memset(taddr->be16, 0, sizeof(taddr->be16));
+    taddr->be16[0] = htons(0xff02);
+    taddr->be16[5] = htons(0x1);
+    taddr->be16[6] = htons(0xff00);
+    memcpy(&addr->s6_addr[13], &ip6->s6_addr[13], 3);
+}
+
 /*
  * Generates ipv6 EUI64 address from the given eth addr
  * and prefix and stores it in 'lla'
@@ -589,6 +601,17 @@ in6_is_lla(struct in6_addr *addr)
          !(addr->s6_addr[2] | addr->s6_addr[3] | addr->s6_addr[4] |
            addr->s6_addr[5] | addr->s6_addr[6] | addr->s6_addr[7]);
 #endif
+}
+
+void
+ipv6_multicast_to_ethernet(struct eth_addr *eth, const struct in6_addr *ip6)
+{
+    eth->ea[0] = 0x33;
+    eth->ea[1] = 0x33;
+    eth->ea[2] = ip6->s6_addr[12];
+    eth->ea[3] = ip6->s6_addr[13];
+    eth->ea[4] = ip6->s6_addr[14];
+    eth->ea[5] = ip6->s6_addr[15];
 }
 
 /* Given the IP netmask 'netmask', returns the number of bits of the IP address

--- a/lib/packets.h
+++ b/lib/packets.h
@@ -1134,17 +1134,8 @@ in6_addr_get_mapped_ipv4(const struct in6_addr *addr)
     }
 }
 
-static inline void
-in6_addr_solicited_node(struct in6_addr *addr, const struct in6_addr *ip6)
-{
-    union ovs_16aligned_in6_addr *taddr =
-        (union ovs_16aligned_in6_addr *) addr;
-    memset(taddr->be16, 0, sizeof(taddr->be16));
-    taddr->be16[0] = htons(0xff02);
-    taddr->be16[5] = htons(0x1);
-    taddr->be16[6] = htons(0xff00);
-    memcpy(&addr->s6_addr[13], &ip6->s6_addr[13], 3);
-}
+void in6_addr_solicited_node(struct in6_addr *addr,
+                             const struct in6_addr *ip6);
 
 void in6_generate_eui64(struct eth_addr ea, const struct in6_addr *prefix,
                         struct in6_addr *lla);
@@ -1154,16 +1145,8 @@ void in6_generate_lla(struct eth_addr ea, struct in6_addr *lla);
 /* Returns true if 'addr' is a link local address.  Otherwise, false. */
 bool in6_is_lla(struct in6_addr *addr);
 
-static inline void
-ipv6_multicast_to_ethernet(struct eth_addr *eth, const struct in6_addr *ip6)
-{
-    eth->ea[0] = 0x33;
-    eth->ea[1] = 0x33;
-    eth->ea[2] = ip6->s6_addr[12];
-    eth->ea[3] = ip6->s6_addr[13];
-    eth->ea[4] = ip6->s6_addr[14];
-    eth->ea[5] = ip6->s6_addr[15];
-}
+void ipv6_multicast_to_ethernet(struct eth_addr *eth,
+                                const struct in6_addr *ip6);
 
 static inline bool dl_type_is_ip_any(ovs_be16 dl_type)
 {

--- a/ovn/northd/lswitch.dl
+++ b/ovn/northd/lswitch.dl
@@ -105,14 +105,21 @@ LogicalSwitchDNS(ls._uuid, dns_uuid) :-
     var dns_uuid = FlatMap(ls.dns_records),
     nb.DNS(._uuid = dns_uuid).
 
+relation LogicalSwitchWithDNSRecords(ls: uuid)
+
+LogicalSwitchWithDNSRecords(ls) :-
+    LogicalSwitchDNS(ls, dns_uuid),
+    nb.DNS(._uuid = dns_uuid, .records = records),
+    not map_is_empty(records).
+
 relation LogicalSwitchHasDNSRecords(ls: uuid, has_dns_records: bool)
 
 LogicalSwitchHasDNSRecords(ls, true) :-
-    LogicalSwitchDNS(ls, _).
+    LogicalSwitchWithDNSRecords(ls).
 
 LogicalSwitchHasDNSRecords(ls, false) :-
     nb.Logical_Switch(._uuid = ls),
-    not LogicalSwitchDNS(.ls_uuid = ls).
+    not LogicalSwitchWithDNSRecords(ls).
 
 /* Switch relation collects all attributes of a logical switch */
 

--- a/ovn/northd/ovn.dl
+++ b/ovn/northd/ovn.dl
@@ -107,6 +107,7 @@ extern function split_addresses(addr: string): (Set<string>, Set<string>)
 extern function in6_generate_lla(ea: eth_addr): in6_addr
 extern function in6_generate_eui64(ea: eth_addr, prefix: in6_addr): in6_addr
 extern function in6_is_lla(addr: in6_addr): bool
+extern function in6_addr_solicited_node(ip6: in6_addr): in6_addr
 
 extern function ipv6_string_mapped(addr: in6_addr): string
 extern function ipv6_parse_masked(s: string): Either<string/*err*/, (in6_addr/*ip*/, in6_addr/*mask*/)>
@@ -117,6 +118,7 @@ extern function ipv6_addr_bitand(a: in6_addr, b: in6_addr): in6_addr
 extern function ipv6_mask_is_any(mask: in6_addr): bool
 extern function ipv6_create_mask(mask: bit<32>): in6_addr
 extern function ipv6_is_zero(a: in6_addr): bool
+extern function ipv6_multicast_to_ethernet(ip6: in6_addr): eth_addr
 extern function scan_eth_addr(s: string): Option<eth_addr>
 extern function scan_eth_addr_prefix(s: string): Option<bit<64>>
 extern function scan_static_dynamic_ip(s: string): Option<ovs_be32>

--- a/ovn/northd/ovn.rs
+++ b/ovn/northd/ovn.rs
@@ -137,6 +137,15 @@ pub fn ovn_in6_is_lla(addr: &ovn_in6_addr) -> bool {
     unsafe {in6_is_lla(addr as *const ovn_in6_addr)}
 }
 
+pub fn ovn_in6_addr_solicited_node(ip6: &ovn_in6_addr) -> ovn_in6_addr
+{
+    let mut res: ovn_in6_addr = Default::default();
+    unsafe {
+        in6_addr_solicited_node(&mut res as *mut ovn_in6_addr, ip6 as *const ovn_in6_addr);
+    }
+    res
+}
+
 pub fn ovn_ipv6_addr_bitand(a: &ovn_in6_addr, b: &ovn_in6_addr) -> ovn_in6_addr {
     unsafe {
         ipv6_addr_bitand(a as *const ovn_in6_addr, b as *const ovn_in6_addr)
@@ -269,6 +278,15 @@ pub fn ovn_ipv6_create_mask(mask: &u32) -> ovn_in6_addr
 pub fn ovn_ipv6_is_zero(a: &ovn_in6_addr) -> bool
 {
     unsafe{ipv6_is_zero(a as *const ovn_in6_addr)}
+}
+
+pub fn ovn_ipv6_multicast_to_ethernet(ip6: &ovn_in6_addr) -> ovn_eth_addr
+{
+    let mut eth: ovn_eth_addr = Default::default();
+    unsafe{
+        ipv6_multicast_to_ethernet(&mut eth as *mut ovn_eth_addr, ip6 as *const ovn_in6_addr);
+    }
+    eth
 }
 
 pub fn ovn_ip_parse_masked(s: &String) -> std_Either<String, (ovn_ovs_be32, ovn_ovs_be32)>
@@ -652,6 +670,7 @@ extern "C" {
     fn ipv6_addr_bitand(a: *const ovn_in6_addr, b: *const ovn_in6_addr) -> ovn_in6_addr;
     fn ipv6_create_mask(mask: raw::c_uint) -> ovn_in6_addr;
     fn ipv6_is_zero(a: *const ovn_in6_addr) -> bool;
+    fn ipv6_multicast_to_ethernet(eth: *mut ovn_eth_addr, ip6: *const ovn_in6_addr);
     fn ip_parse_masked(s: *const raw::c_char, ip: *mut ovn_ovs_be32, mask: *mut ovn_ovs_be32) -> *mut raw::c_char;
     fn ip_parse_cidr(s: *const raw::c_char, ip: *mut ovn_ovs_be32, plen: *mut raw::c_uint) -> *mut raw::c_char;
     fn ip_parse(s: *const raw::c_char, ip: *mut ovn_ovs_be32) -> bool;
@@ -659,14 +678,16 @@ extern "C" {
     fn eth_addr_to_uint64(ea: ovn_eth_addr) -> libc::uint64_t;
     fn eth_addr_from_uint64(x: libc::uint64_t, ea: *mut ovn_eth_addr);
     fn eth_addr_mark_random(ea: *mut ovn_eth_addr);
+    fn in6_generate_eui64(ea: ovn_eth_addr, prefix: *const ovn_in6_addr, lla: *mut ovn_in6_addr);
+    fn in6_generate_lla(ea: ovn_eth_addr, lla: *mut ovn_in6_addr);
+    fn in6_is_lla(addr: *const ovn_in6_addr) -> bool;
+    fn in6_addr_solicited_node(addr: *mut ovn_in6_addr, ip6: *const ovn_in6_addr);
+
     // include/openvswitch/json.h
     fn json_string_escape(str: *const raw::c_char, out: *mut ovs_ds);
     // openvswitch/dynamic-string.h
     fn ds_destroy(ds: *mut ovs_ds);
     fn ds_cstr(ds: *const ovs_ds) -> *const raw::c_char;
-    fn in6_generate_lla(ea: ovn_eth_addr, lla: *mut ovn_in6_addr);
-    fn in6_generate_eui64(ea: ovn_eth_addr, prefix: *const ovn_in6_addr, lla: *mut ovn_in6_addr);
-    fn in6_is_lla(addr: *const ovn_in6_addr) -> bool;
     fn svec_destroy(v: *mut ovs_svec);
     fn ovs_scan(s: *const raw::c_char, format: *const raw::c_char, ...) -> bool;
     fn count_1bits(x: libc::uint64_t) -> raw::c_uint;

--- a/ovn/northd/ovn_northd.dl
+++ b/ovn/northd/ovn_northd.dl
@@ -4587,6 +4587,32 @@ for (&Router(.dpname = dpname,
  * In the common case where the Ethernet destination has been resolved,
  * this table outputs the packet (priority 0).  Otherwise, it composes
  * and sends an ARP/IPv6 NA request (priority 100). */
+
+for (RouterStaticRoute(.router      = &router,
+                       .route       = &route,
+                       .output_port = &out_port,
+                       .lrp_addr_s  = lrp_addr_s))
+{
+    Right{(var gw_ip6, 128)} = ipv6_parse_cidr(route.lrsr.nexthop) in
+    var __match = "eth.dst == 00:00:00:00:00:00 && "
+                  "ip6 && xxreg0 == ${route.lrsr.nexthop}" in
+    var sn_addr = in6_addr_solicited_node(gw_ip6) in
+    var eth_dst = ipv6_multicast_to_ethernet(sn_addr) in
+    var sn_addr_s = ipv6_string_mapped(sn_addr) in
+    var actions = "nd_ns { "
+                  "eth.dst = ${eth_dst}; "
+                  "ip6.dst = ${sn_addr_s}; "
+                  "nd.target = ${route.lrsr.nexthop}; "
+                  "output; "
+                  "};" in
+    Flow(.logical_datapath = router.dpname,
+         .stage         = router_stage(IN, ARP_REQUEST),
+         .priority         = 200,
+         .__match          = __match,
+         .actions          = actions,
+         .external_ids     = map_empty())
+}
+
 for (&Router(.dpname = dpname))
 {
     Flow(.logical_datapath = dpname,

--- a/ovn/northd/ovn_northd.dl
+++ b/ovn/northd/ovn_northd.dl
@@ -735,18 +735,10 @@ sb.Out_DHCPv6_Options (
 
 sb.Out_DNS(.records      = nbdns.records,
            .datapaths    = datapaths,
-           .external_ids = nbdns.external_ids) :-
+           .external_ids = map_insert_imm(nbdns.external_ids, "dns_id", uuid2str(nbdns._uuid))) :-
     nb.DNS[nbdns],
     LogicalSwitchDNS(ls_uuid, nbdns._uuid),
     var datapaths = Aggregate((nbdns), group2set(uuid2name(ls_uuid))).
-
-/*
-sb.Out_DNS(.records      = nbdns.records,
-           .datapaths    = set_empty(),
-           .external_ids = nbdns.external_ids) :-
-    nb.DNS[nbdns],
-    not LogicalSwitchDNS(_, nbdns._uuid).
-*/
 
 /*
  * RBAC_Permission: fixed

--- a/ovn/northd/ovn_northd.dl
+++ b/ovn/northd/ovn_northd.dl
@@ -94,7 +94,7 @@ sb.Out_Port_Binding(.uuid_name          = uuid2name(lsp._uuid),
     &SwitchPort(.lsp = lsp, .sw = &sw),
     SwitchPortNewDynamicTag(lsp._uuid, opt_tag),
     var tag: Set<integer> = match (opt_tag) {
-        None -> set_empty(),
+        None -> lsp.tag,
         Some{t} -> set_singleton(t)
     },
     lsp.__type != "router",
@@ -304,6 +304,8 @@ RouterPortRAOptionsComplete(lrp, map_empty()) :-
     not RouterPortRAOptions(lrp, _).
 
 
+function gateway_chassis_uuid_name(lr_uuid: uuid): string = { "gw" ++ uuid2name(lr_uuid) }
+
 /*
  * Create derived port for Logical_Router_Ports with non-empty 'gateway_chassis' column.
  */
@@ -325,7 +327,7 @@ sb.Out_Port_Binding(.uuid_name          = "cr" ++ uuid2name(lrp._uuid),
     var gateway_chassis = if (not set_is_empty(lrp.gateway_chassis)) {
         set_map_uuid2name(lrp.gateway_chassis)
     } else {
-        set_singleton(uuid2name(lr_uuid))
+        set_singleton(gateway_chassis_uuid_name(lr_uuid))
     }.
 
 /* Create sb.Gateway_Chassis for derived ports.
@@ -344,7 +346,7 @@ sb.Out_Gateway_Chassis(.uuid_name       = uuid2name(gateway_chassis_uuid),
     gw_chassis in nb.Gateway_Chassis(._uuid = gateway_chassis_uuid),
     sb.Chassis(._uuid = chassis_uuid, .name = gw_chassis.chassis_name).
 
-sb.Out_Gateway_Chassis(.uuid_name       = uuid2name(lr_uuid),
+sb.Out_Gateway_Chassis(.uuid_name       = gateway_chassis_uuid_name(lr_uuid),
                        .name            = "${lrp.name}_${redirect_chassis}",
                        .chassis         = set_singleton(chassis_uuid),
                        .priority        = 0,
@@ -834,7 +836,7 @@ nb.Out_Logical_Switch_Port(.uuid_name              = uuid2name(lsp._uuid),
     },
     SwitchPortNewDynamicTag(lsp._uuid, opt_tag),
     var tag: Set<integer> = match (opt_tag) {
-        None -> set_empty(),
+        None -> lsp.tag,
         Some{t} -> set_singleton(t)
     }.
 
@@ -2628,7 +2630,8 @@ for (&SwitchPort(.lsp = lsp,
                  .sw = &sw,
                  .peer = Some{&RouterPort{.lrp = lrp,
                                           .is_redirect = is_redirect,
-                                          .router = &Router{.lr = lr}}})
+                                          .router = &Router{.lr = lr,
+                                                            .redirect_port_name = redirect_port_name}}})
      if (set_contains(lsp.addresses, "router")))
 {
     Some{var mac} = scan_eth_addr(lrp.mac) in {
@@ -2651,7 +2654,7 @@ for (&SwitchPort(.lsp = lsp,
             /* The destination lookup flow for the router's
              * distributed gateway port MAC address should only be
              * programmed on the "redirect-chassis". */
-            "eth.dst == ${mac} && is_chassis_resident(${json_string_escape(chassis_redirect_name(lrp.name))})"
+            "eth.dst == ${mac} && is_chassis_resident(${redirect_port_name})"
         } else {
             "eth.dst == ${mac}"
         } in
@@ -3087,7 +3090,7 @@ for (RouterPortNetworksIPv4Addr(.port = &RouterPort{.lrp = lrp,
             "&& arp.tpa == ${addr.addr_s}"
             " && arp.op == 1" ++
             if (add_chassis_resident_check) {
-                " && is_chassis_resident(${json_string_escape(chassis_redirect_name(lrp.name))})"
+                " && is_chassis_resident(${router.redirect_port_name})"
             } else "" in
         var actions =
             "put_arp(inport, arp.spa, arp.sha); "
@@ -4811,6 +4814,8 @@ QueueIDAllocation(port, Some{qid}) :-
  * 1. For ports that need a dynamically allocated tag, existing tag, if any,
  * 2. For ports that have a statically assigned tag (via `tag_request`), the
  *    `tag_request` value.
+ * 3. For ports that do not have a tag_request, but have a tag statically assigned
+ *    by directly setting the `tag` field, use this value.
  */
 output relation SwitchPortReservedTag(parent_name: string, tags: integer)
 
@@ -4819,7 +4824,10 @@ SwitchPortReservedTag(parent_name, tag) :-
     Some{var tag} = if (needs_dynamic_tag) {
         set_nth(lsp.tag, 0)
     } else {
-        set_nth(lsp.tag_request, 0)
+        match (set_nth(lsp.tag_request, 0)) {
+            Some{req} -> Some{req},
+            None      -> set_nth(lsp.tag, 0)
+        }
     }.
 
 output relation SwitchPortReservedTags(parent_name: string, tags: Set<integer>)

--- a/ovn/northd/ovn_northd.dl
+++ b/ovn/northd/ovn_northd.dl
@@ -255,7 +255,7 @@ function get_nat_addresses(rport: RouterPort): Set<string> =
                                 match (eth_addr_from_string(set_space_sep(nat.external_mac))) {
                                     Some{emac} -> {
                                         set_insert(addresses,
-                                                   "${emac} ${nat.external_ip} is_chassis_resident(\"set_space_sep(nat.logical_port)\")")
+                                                   "${emac} ${nat.external_ip} is_chassis_resident(\"${set_space_sep(nat.logical_port)}\")")
                                     },
                                     None -> ()
                                 }
@@ -282,7 +282,7 @@ function get_nat_addresses(rport: RouterPort): Set<string> =
                 /* Gratuitous ARP for centralized NAT rules on distributed gateway
                  * ports should be restricted to the "redirect-chassis". */
                 if (has_redirect) {
-                    c_addresses = c_addresses ++ " is_chassis_resident(router.redirect_port_name)"
+                    c_addresses = c_addresses ++ " is_chassis_resident(${router.redirect_port_name})"
                 } else ();
 
                 set_insert(addresses, c_addresses)

--- a/ovn/northd/ovn_northd.dl
+++ b/ovn/northd/ovn_northd.dl
@@ -4239,7 +4239,7 @@ for (&RouterPort[port@RouterPort{.lrp = lrp@nb.Logical_Router_Port{.peer = set_e
                           "outport = inport; flags.loopback = 1; "
                           "output;" in
             Flow(.logical_datapath = router.dpname,
-                 .stage         = router_stage(IN, ND_RA_OPTIONS),
+                 .stage         = router_stage(IN, ND_RA_RESPONSE),
                  .priority         = 50,
                  .__match          = __match,
                  .actions          = actions,

--- a/ovn/northd/ovn_northd.dl
+++ b/ovn/northd/ovn_northd.dl
@@ -740,11 +740,13 @@ sb.Out_DNS(.records      = nbdns.records,
     LogicalSwitchDNS(ls_uuid, nbdns._uuid),
     var datapaths = Aggregate((nbdns), group2set(uuid2name(ls_uuid))).
 
+/*
 sb.Out_DNS(.records      = nbdns.records,
            .datapaths    = set_empty(),
            .external_ids = nbdns.external_ids) :-
     nb.DNS[nbdns],
     not LogicalSwitchDNS(_, nbdns._uuid).
+*/
 
 /*
  * RBAC_Permission: fixed
@@ -2532,7 +2534,7 @@ for (LogicalSwitchHasDNSRecords(ls, true))
     var lsname = uuid2name(ls) in
     {
         Flow(.logical_datapath = lsname,
-             .stage         = switch_stage(IN, DNS_RESPONSE),
+             .stage         = switch_stage(IN, DNS_LOOKUP),
              .priority         = 100,
              .__match          = "udp.dst == 53",
              .actions          = "${rEGBIT_DNS_LOOKUP_RESULT()} = dns_lookup(); next;",

--- a/tests/ovn-northd.at
+++ b/tests/ovn-northd.at
@@ -94,7 +94,8 @@ AT_CHECK([test x`ovn-nbctl lsp-get-up S1-vm1` = xdown])
 
 ovn-sbctl chassis-add hv1 geneve 127.0.0.1
 ovn-sbctl lsp-bind S1-vm1 hv1
-AT_CHECK([test x`ovn-nbctl lsp-get-up S1-vm1` = xup])
+
+OVS_WAIT_UNTIL([test x`ovn-nbctl lsp-get-up S1-vm1` = xup])
 
 AT_CLEANUP
 


### PR DESCRIPTION
The only OVN tests failing now are due to different tag/tunnel allocation algorithms used by C and DDlog and due to `ovn-sbctl` and `ovn_controller_vtep` tests not liking the warning messages that `ovn-northd-ddlog.c` prints in the log.