### PR TITLE
ovn/northd/automake.mk: flags to speedup compilation

### DIFF
--- a/ovn/northd/automake.mk
+++ b/ovn/northd/automake.mk
@@ -79,7 +79,17 @@ ovn/northd/OVN_Southbound.dl: ovn/ovn-sb.ovsschema
 
 CLEANFILES += ovn/northd/OVN_Northbound.dl ovn/northd/OVN_Southbound.dl
 
-ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli: \
+ovn/northd/ovn_northd_ddlog/ddlog.h: \
+	ovn/northd/ovn_northd_ddlog/target/release/libovn_northd_ddlog.a
+
+ovn/northd/ovn_northd_ddlog/target/release/libovn_northd_ddlog.la: \
+	ovn/northd/ovn_northd_ddlog/target/release/libovn_northd_ddlog.a
+
+#EXTRA_RUSTFLAGS=-C opt-level=z
+EXTRA_RUSTFLAGS=
+LIB_ONLY_FLAG=--lib
+
+ovn/northd/ovn_northd_ddlog/target/release/libovn_northd_ddlog.a: \
 	ovn/northd/ovn_northd.dl	 \
 	ovn/northd/lswitch.dl	 	 \
 	ovn/northd/lrouter.dl	 	 \
@@ -91,20 +101,15 @@ ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli: \
 	ovn/northd/OVN_Southbound.dl
 	$(AM_V_GEN)ddlog -i $< -L @DDLOG_LIB@
 	$(AM_V_at)cd ovn/northd/ovn_northd_ddlog && \
-		RUSTFLAGS='-L ../../lib/.libs -L ../../../lib/.libs -lssl -lcrypto -Awarnings' cargo build --release
+		RUSTFLAGS="-L ../../lib/.libs -L ../../../lib/.libs -lssl -lcrypto -Awarnings $(EXTRA_RUSTFLAGS)" cargo build --release $(LIB_ONLY_FLAG)
 
 CLEAN_LOCAL += clean-ddlog
 clean-ddlog:
 	rm -rf ovn/northd/ovn_northd_ddlog
 
-ovn/northd/ovn_northd_ddlog/target/release/libovn_northd_ddlog.la: \
-	ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli
-
-ovn/northd/ovn_northd_ddlog/ddlog.h: \
-	ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli
-
 CLEANFILES += \
 	ovn/northd/ovn_northd_ddlog/target/release/libovn_northd_ddlog.la \
 	ovn/northd/ovn_northd_ddlog/ddlog.h \
+	ovn/northd/ovn_northd_ddlog/target/release/libovn_northd_ddlog.a \
 	ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli
 endif


### PR DESCRIPTION
Introduces two variables that control DDlog compilation speed.

1. `LIB_ONLY_FLAG`.  When set to `--lib` (which should be the default),
   only compiles static library and not the standalone `ovn_northd_cli`
   executable.  The latter is only used for debugging and is not needed
   for `northd` to work.

2. `EXTRA_RUSTFLAGS`.  This variable controls Rust compiler flags, in
   particular optimization level.  Leave empty (default) to compile with
   `-O 2`, which takes a while, but produces faster code.  Set to
   `-C opt-level=z` for faster compilation, but slower code.  This may
   be useful at development time for faster edit/compile/run cycle.

These variables should eventually be controlled by `configure` options,
e.g.,

`--ddlog-northd-cli` - sets `LIB_ONLY_FLAG` to empty
`--ddlog-northd-fast-build` - sets `EXTRA_RUSTFLAGS` to `-C opt-level=z`