### PR TITLE
ovn-northd-ddlog: Add ip/ip6 in match condition for ARP request flows.

### DIFF
--- a/ovn/northd/ovn_northd.dl
+++ b/ovn/northd/ovn_northd.dl
@@ -4637,7 +4637,7 @@ for (&Router(.dpname = dpname))
     Flow(.logical_datapath = dpname,
          .stage         = router_stage(IN, ARP_REQUEST),
          .priority         = 100,
-         .__match          = "eth.dst == 00:00:00:00:00:00",
+         .__match          = "eth.dst == 00:00:00:00:00:00 && ip",
          .actions          = "arp { "
                              "eth.dst = ff:ff:ff:ff:ff:ff; "
                              "arp.spa = reg1; "
@@ -4650,7 +4650,7 @@ for (&Router(.dpname = dpname))
     Flow(.logical_datapath = dpname,
          .stage         = router_stage(IN, ARP_REQUEST),
          .priority         = 100,
-         .__match          = "eth.dst == 00:00:00:00:00:00",
+         .__match          = "eth.dst == 00:00:00:00:00:00 && ip6",
          .actions          = "nd_ns { "
                              "nd.target = xxreg0; "
                              "output; "


### PR DESCRIPTION
In C implementation, protocol type is not added, and it relies on
ovn-controller to add the prerequisit in match condition when
translating actions, i.e. ipv4 for arp, and ipv6 for nd_ns.

However, with ddlog, when generating logical flows, if two flows
have same match condition, ddlog will keep updating the SB DB
for both flows interchanging the actions continuously, costing
high CPU. This patch is a workaround to avoid the problem, and it
is not harmful to specify the protocol type clearly.

Root cause still needs to be found in ddlog to avoid other similar
problems, e.g. when conflicting MAC addresses configured, ddlog
will result in same busy-loop behavior.

Signed-off-by: Han Zhou <hzhou8@ebay.com>