### PR TITLE
ovn/northd/automake.mk: make `actions` part of primary key

### DIFF
--- a/ovn/northd/automake.mk
+++ b/ovn/northd/automake.mk
@@ -77,6 +77,7 @@ ovn/northd/OVN_Southbound.dl: ovn/ovn-sb.ovsschema
 				-k Logical_Flow.table_id		\
 				-k Logical_Flow.priority		\
 				-k Logical_Flow.match			\
+				-k Logical_Flow.actions			\
 				> $@
 
 CLEANFILES += ovn/northd/OVN_Northbound.dl ovn/northd/OVN_Southbound.dl


### PR DESCRIPTION
In an earlier commit I tried to optimize things by specifying a primary
key for the `Logical_Flow` table to not include the `actions` column.
This assumes that there cannot be two flows for the same logical
datapath with the same match condition and priority but different actions.
Unfortunately, some flows violate this assumption.  This happens for
example when part of the match condition (e.g., `ip4`/`ip6`) is implied
by the action.

The fix is to make `actions` part of the primary key.