### PR TITLE
ovn-northd-ddlog: fix handling of read-only SB_Global columns 

### DIFF
--- a/ovn/northd/automake.mk
+++ b/ovn/northd/automake.mk
@@ -62,6 +62,9 @@ ovn/northd/OVN_Southbound.dl: ovn/ovn-sb.ovsschema
 				-p Port_Binding     	\
 				--ro Port_Binding.chassis       \
 				--ro Port_Binding.encap         \
+				--ro SB_Global.ssl              \
+				--ro SB_Global.connections      \
+				--ro SB_Global.external_ids     \
 				-k Multicast_Group.datapath     \
 				-k Multicast_Group.name         \
 				-k Multicast_Group.tunnel_key   \

--- a/ovn/northd/docs/debugging.md
+++ b/ovn/northd/docs/debugging.md
@@ -144,7 +144,7 @@ To enable recording, simply uncomment the following line in
 ```
 
 DDlog should now create a `replay.dat` file, which contains the log of transactions
-in the DDlog command format documente
+in the DDlog command format documented
 [here](https://github.com/ryzhyk/differential-datalog/blob/master/doc/testing/testing.md#command-reference).
 
 To replay the log, use the DDlog executable compiled along with the static library:

--- a/ovn/northd/ovn_northd.dl
+++ b/ovn/northd/ovn_northd.dl
@@ -386,17 +386,11 @@ sb.OutProxy_Port_Binding(.uuid_name          = pbinding.uuid_name,
  */
 for (nb_global in nb.NB_Global) {
     sb.Out_SB_Global(.nb_cfg         = nb_global.nb_cfg,
-                     .external_ids   = nb_global.external_ids,
-                     .connections    = nb_global.connections,
-                     .ssl            = nb_global.ssl,
                      .options        = nb_global.options,
                      .ipsec          = nb_global.ipsec)
 }
 
 sb.Out_SB_Global(.nb_cfg         = sb_global.nb_cfg,
-                 .external_ids   = sb_global.external_ids,
-                 .connections    = sb_global.connections,
-                 .ssl            = sb_global.ssl,
                  .options        = sb_global.options,
                  .ipsec          = sb_global.ipsec) :-
     sb_global in sb.SB_Global(),


### PR DESCRIPTION
The following `SB_Global` columns should not be touched by northd:
`ssl`, `connections`, `external_ids`.

Add these columns to the read-only list in `automake.mk` and remove
references to them from `ovn_northd.dl`.

dccdd0b 