### PR TITLE
ovn/northd/automake.mk: get rid of fake NB_Global key

### DIFF
--- a/ovn/northd/automake.mk
+++ b/ovn/northd/automake.mk
@@ -37,7 +37,6 @@ ovn/northd/OVN_Northbound.dl: ovn/ovn-nb.ovsschema
 				--ro NB_Global.external_ids     \
 				--ro NB_Global.connections      \
 				--ro NB_Global.ssl              \
-				-k NB_Global.ipsec              \
 				> $@
 
 ovn/northd/OVN_Southbound.dl: ovn/ovn-sb.ovsschema


### PR DESCRIPTION
DDlog used to handle updates to `NB_Global` and `SB_Global` tables in hacky
way.  For `NB_Global`, in order to make sure that DDlog updates the
existing record rather than delete and re-insert it on every change, we
used `ipsec` field as a key, which is bogus.  For `SB_Global`, there is
no column that can be used as even a bogus key, so we actually used the
delete/re-insert approach instead.  This could lead to a race if the
table changed while DDlog was updating it.

DDlog now handles such tables (namely, tables with `maxRows` property equal
to 1) by interpreting them as having a key consisting of an empty list of
columns, so there is no need for the fake key any longer.